### PR TITLE
Disables kilo repository on CentoOS

### DIFF
--- a/centos/scripts/dep.sh
+++ b/centos/scripts/dep.sh
@@ -12,6 +12,7 @@ cd system-config
 bash install_puppet.sh
 bash install_modules.sh
 
+yum-config-manager --save --setopt=openstack-kilo.skip_if_unavailable=true
 yum -y update
 
 echo "Rebooting"


### PR DESCRIPTION
The repository is being installed as part of the `script/deps.sh`
process, and adds a IPv6 only repo.

This causes yum to bork. So we disable if it is not accessible.
